### PR TITLE
Remove print.knitr_kable override

### DIFF
--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -160,6 +160,10 @@
       )
     }
   })
+  rm(list = "print.knitr_kable",
+     envir = as.environment("tools:rstudio"),
+     inherits = FALSE
+  )   
 })
 
 .rs.addFunction("readDataCapture", function(path)


### PR DESCRIPTION
After running a notebook chunk, print.knitr_kable was left in the tools:rstudio environment, so knitr::kable() objects didn't print properly in the console.  See https://stackoverflow.com/questions/45884403/knitrkable-does-not-pretty-print-after-running-an-r-chunk .

I think this patch is the correct minimal fix, but it might make more sense to also change `initDataCapture` to make `print.knitr_kable` more like the other `print` overrides.